### PR TITLE
Benchmark

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,67 @@
+package engi_test
+
+import (
+	"github.com/paked/engi"
+	"testing"
+)
+
+// BenchmarkEmpty creates the game, and measures the runtime of a single frame, w/o anything set up
+func BenchmarkEmpty(b *testing.B) {
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkSystem10 creates 10 `NilSystem`s
+func BenchmarkSystem10(b *testing.B) {
+	const count = 10
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		for i := 0; i < count; i++ {
+			w.AddSystem(&engi.NilSystem{})
+		}
+	}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkSystem1000 creates 1000 `NilSystem`s
+func BenchmarkSystem1000(b *testing.B) {
+	const count = 1000
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		for i := 0; i < count; i++ {
+			w.AddSystem(&engi.NilSystem{})
+		}
+	}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkEntity10 creates 10 `Entity`s which all depend on the `NilSystem`
+func BenchmarkEntity10(b *testing.B) {
+	const count = 10
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		w.AddSystem(&engi.NilSystem{})
+		for i := 0; i < count; i++ {
+			w.AddEntity(engi.NewEntity([]string{"NilSystem"}))
+		}
+	}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkEntity1000 creates 1000 `Entity`s which all depend on the `NilSystem`
+func BenchmarkEntity1000(b *testing.B) {
+	const count = 1000
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		w.AddSystem(&engi.NilSystem{})
+		for i := 0; i < count; i++ {
+			w.AddEntity(engi.NewEntity([]string{"NilSystem"}))
+		}
+	}
+	engi.Bench(b, preload, setup)
+}

--- a/camera_test.go
+++ b/camera_test.go
@@ -140,8 +140,8 @@ func TestCameraZoomTo(t *testing.T) {
 
 	currentZ := cam.Z()
 
-	cam.zoomTo(currentZ + 5)
-	assert.Equal(t, cam.Z(), currentZ+5, "Zooming to current + 5 should get us to current + 5")
+	cam.zoomTo(currentZ + 1)
+	assert.Equal(t, cam.Z(), currentZ+1, "Zooming to current + 1 should get us to current + 1")
 
 	cam.zoomTo(600)
 	assert.Equal(t, cam.Z(), MaxZoom, "Zooming too close, should get us to the minimum distance")

--- a/engi.go
+++ b/engi.go
@@ -45,6 +45,16 @@ func OpenHeadless(r Responder) {
 	runHeadless()
 }
 
+func OpenHeadlessNoRun(r Responder) {
+	Time = NewClock()
+	Files = NewLoader() // TODO: do we want files in Headless mode?
+
+	// TODO: change these (#35)
+	responder = r
+	Wo = r
+	headless = true
+}
+
 func SetBg(color uint32) {
 	if !headless {
 		r := float32((color>>16)&0xFF) / 255.0

--- a/system.go
+++ b/system.go
@@ -102,6 +102,20 @@ func (*CollisionSystem) Type() string {
 	return "CollisionSystem"
 }
 
+type NilSystem struct {
+	*System
+}
+
+func (ns *NilSystem) New() {
+	ns.System = &System{}
+}
+
+func (*NilSystem) Update(*Entity, float32) {}
+
+func (*NilSystem) Type() string {
+	return "NilSystem"
+}
+
 type PriorityLevel int
 
 const (

--- a/system_test.go
+++ b/system_test.go
@@ -1,0 +1,57 @@
+package engi_test
+
+import (
+	"github.com/paked/engi"
+	"testing"
+)
+
+// BenchmarkCollisionSystem10 creates 10 entities, of which half are solid, and all are Main
+func BenchmarkCollisionSystem10(b *testing.B) {
+	const count = 10
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		w.AddSystem(&engi.CollisionSystem{})
+		for i := 0; i < count; i++ {
+			ent := engi.NewEntity([]string{"CollisionSystem"})
+			ent.AddComponent(&engi.SpaceComponent{engi.Point{0, 0}, 10, 10})
+			ent.AddComponent(&engi.CollisionComponent{Solid: i%2 == 0, Main: true})
+			w.AddEntity(ent)
+		}
+	}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkCollisionSystem100 creates 100 entities, of which half are solid, and all are Main
+func BenchmarkCollisionSystem100(b *testing.B) {
+	const count = 100
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		w.AddSystem(&engi.CollisionSystem{})
+		for i := 0; i < count; i++ {
+			ent := engi.NewEntity([]string{"CollisionSystem"})
+			ent.AddComponent(&engi.SpaceComponent{engi.Point{0, 0}, 10, 10})
+			ent.AddComponent(&engi.CollisionComponent{Solid: i%2 == 0, Main: true})
+			w.AddEntity(ent)
+		}
+	}
+	engi.Bench(b, preload, setup)
+}
+
+// BenchmarkCollisionSystem1000 creates 1000 entities, of which half are solid, and all are Main
+func BenchmarkCollisionSystem1000(b *testing.B) {
+	const count = 1000
+
+	preload := func(w *engi.World) {}
+	setup := func(w *engi.World) {
+		w.AddSystem(&engi.CollisionSystem{})
+		for i := 0; i < count; i++ {
+			ent := engi.NewEntity([]string{"CollisionSystem"})
+			ent.AddComponent(&engi.SpaceComponent{engi.Point{0, 0}, 10, 10})
+			ent.AddComponent(&engi.CollisionComponent{Solid: i%2 == 0, Main: true})
+			w.AddEntity(ent)
+		}
+	}
+	engi.Bench(b, preload, setup)
+}


### PR DESCRIPTION
Added some benchmarks (not all of which are as useful), to benchmark certain `System`s.

Please review @matiwinnetou @paked, as I did some refactoring of the `Open` and `run` functions, which possibly could be done in a better manner. 


Some output:
```
➜  engi git:(benchmark) go test -bench .                                     
PASS
BenchmarkEmpty-8              	10000000	       116 ns/op
BenchmarkSystem10-8           	 5000000	       309 ns/op
BenchmarkSystem1000-8         	  100000	     17569 ns/op
BenchmarkEntity10-8           	10000000	       179 ns/op
BenchmarkEntity1000-8         	  300000	      3961 ns/op
BenchmarkCollisionSystem10-8  	   50000	     39614 ns/op
BenchmarkCollisionSystem100-8 	     500	   4015496 ns/op
BenchmarkCollisionSystem1000-8	       3	 446231737 ns/op
ok  	github.com/paked/engi	15.830s
```

This also allows for some profiling:

```
      flat  flat%   sum%        cum   cum%
    1560ms 16.27% 16.27%     2050ms 21.38%  runtime.mallocgc
    1080ms 11.26% 27.53%     2190ms 22.84%  runtime.mapaccess2
     820ms  8.55% 36.08%     8110ms 84.57%  github.com/paked/engi.(*CollisionSystem).Update
     670ms  6.99% 43.07%     4730ms 49.32%  github.com/paked/engi.(*Entity).GetComponent
     530ms  5.53% 48.59%      530ms  5.53%  reflect.ValueOf
     400ms  4.17% 52.76%      400ms  4.17%  runtime.aeshash64
     400ms  4.17% 56.93%      800ms  8.34%  runtime.interhash
     350ms  3.65% 60.58%      350ms  3.65%  runtime.mSpan_Sweep.func1
     340ms  3.55% 64.13%      340ms  3.55%  reflect.Value.Elem
     210ms  2.19% 66.32%     2260ms 23.57%  runtime.newobject
     190ms  1.98% 68.30%      670ms  6.99%  reflect.Value.Set
     190ms  1.98% 70.28%      280ms  2.92%  reflect.Value.assignTo
     180ms  1.88% 72.16%      180ms  1.88%  runtime.ifaceeq
     160ms  1.67% 73.83%      160ms  1.67%  reflect.Value.Type
     150ms  1.56% 75.39%      500ms  5.21%  runtime.heapBitsSweepSpan
     140ms  1.46% 76.85%      140ms  1.46%  runtime.xchg
     130ms  1.36% 78.21%      130ms  1.36%  runtime.futex
     130ms  1.36% 79.56%      310ms  3.23%  runtime.interequal
     130ms  1.36% 80.92%      130ms  1.36%  runtime.prefetchnta
     110ms  1.15% 82.06%      170ms  1.77%  runtime.convI2E
```