### PR TITLE
Fixed bug in RenderSystem

### DIFF
--- a/system.go
+++ b/system.go
@@ -206,7 +206,7 @@ func (rs *RenderSystem) Post() {
 			var space *SpaceComponent
 
 			if !entity.GetComponent(&render) || !entity.GetComponent(&space) {
-				return
+				continue
 			}
 
 			render.Display.Render(batch, render, space)


### PR DESCRIPTION
Whenever an item requiring the RenderSystem, didn't have a SpaceComponent, engi would crash.
This is fixed now.