### PR TITLE
Added ComponentFast + Benchmarks

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -75,9 +75,13 @@ func (a *AnimationSystem) Update(e *Entity, dt float32) {
 	var (
 		ac *AnimationComponent
 		r  *RenderComponent
+		ok bool
 	)
 
-	if !e.Component(&ac) || !e.Component(&r) {
+	if ac, ok = e.ComponentFast(ac).(*AnimationComponent); !ok {
+		return
+	}
+	if r, ok = e.ComponentFast(r).(*RenderComponent); !ok {
 		return
 	}
 

--- a/assets.go
+++ b/assets.go
@@ -98,6 +98,11 @@ func (l *Loader) Load(onFinish func()) {
 			if err == nil {
 				l.images[r.name] = NewTexture(data)
 			}
+		case "jpg":
+			data, err := loadImage(r)
+			if err == nil {
+				l.images[r.name] = NewTexture(data)
+			}
 		case "json":
 			data, err := loadJson(r)
 			if err == nil {

--- a/audio.go
+++ b/audio.go
@@ -18,7 +18,7 @@ type AudioComponent struct {
 	player     *Player
 }
 
-func (AudioComponent) Type() string {
+func (*AudioComponent) Type() string {
 	return "AudioComponent"
 }
 
@@ -58,7 +58,8 @@ func (as *AudioSystem) New() {
 
 func (as *AudioSystem) Update(entity *Entity, dt float32) {
 	var ac *AudioComponent
-	if !entity.Component(&ac) {
+	var ok bool
+	if ac, ok = entity.ComponentFast(ac).(*AudioComponent); !ok {
 		return
 	}
 
@@ -96,7 +97,8 @@ func (as *AudioSystem) Update(entity *Entity, dt float32) {
 
 		if !ac.Background {
 			var space *SpaceComponent
-			if !entity.Component(&space) {
+			var ok bool
+			if space, ok = entity.ComponentFast(space).(*SpaceComponent); !ok {
 				return
 			}
 

--- a/camera.go
+++ b/camera.go
@@ -66,7 +66,8 @@ func (cam *cameraSystem) New() {
 func (cam *cameraSystem) FollowEntity(entity *Entity) {
 	cam.tracking = entity
 	var space *SpaceComponent
-	if !cam.tracking.Component(&space) {
+
+	if _, ok := cam.tracking.ComponentFast(space).(*SpaceComponent); !ok {
 		cam.tracking = nil
 		return
 	}
@@ -114,7 +115,9 @@ func (cam *cameraSystem) Update(entity *Entity, dt float32) {
 	}
 
 	var space *SpaceComponent
-	if !cam.tracking.Component(&space) {
+	var ok bool
+
+	if space, ok = cam.tracking.ComponentFast(space).(*SpaceComponent); !ok {
 		return
 	}
 

--- a/entity.go
+++ b/entity.go
@@ -28,23 +28,30 @@ func (e *Entity) DoesRequire(name string) bool {
 }
 
 func (e *Entity) AddComponent(component Component) {
-	e.components[reflect.TypeOf(component).String()] = component
+	e.components[component.Type()] = component
 }
 
 func (e *Entity) RemoveComponent(component Component) {
-	delete(e.components, reflect.TypeOf(component).String())
+	delete(e.components, component.Type())
 }
 
 // GetComponent takes a double pointer to a Component,
 // and populates it with the value of the right type.
 func (e *Entity) Component(x interface{}) bool {
 	v := reflect.ValueOf(x).Elem() // *T
-	c, ok := e.components[v.Type().String()]
+	c, ok := e.components[v.Interface().(Component).Type()]
 	if !ok {
 		return false
 	}
 	v.Set(reflect.ValueOf(c))
 	return true
+}
+
+// ComponentFast returns the same object as GetComponent
+// but without using reflect (and thus faster)
+// Be sure to define the .Type() such that it takes a pointer receiver
+func (e *Entity) ComponentFast(c Component) interface{} {
+	return e.components[c.Type()]
 }
 
 func (e *Entity) ID() string {

--- a/entity_test.go
+++ b/entity_test.go
@@ -1,0 +1,136 @@
+package engi
+
+import (
+	"testing"
+)
+
+const (
+	benchmarkComponentCount = 1000
+)
+
+type getComponentSystem struct {
+	*System
+}
+
+func (getComponentSystem) Type() string {
+	return "getComponentSystem"
+}
+
+func (g *getComponentSystem) New() {
+	g.System = NewSystem()
+}
+
+func (g *getComponentSystem) Update(entity *Entity, dt float32) {
+	var sp *SpaceComponent
+	if !entity.Component(&sp) {
+		return
+	}
+	// Not needed, but we need to ensure it gets compiled correctly
+	if sp == nil {
+		return
+	}
+
+	if len(entity.components) != 2 {
+		return
+	}
+
+	var ren *RenderComponent
+	if !entity.Component(&ren) {
+		return
+	}
+	// Not needed, but we need to ensure it gets compiled correctly
+	if ren == nil {
+		return
+	}
+}
+
+func BenchmarkComponent(b *testing.B) {
+	preload := func() {}
+	setup := func(w *World) {
+		w.AddSystem(&getComponentSystem{})
+		for i := 0; i < benchmarkComponentCount; i++ {
+			e := NewEntity([]string{"getComponentSystem"})
+			e.AddComponent(&SpaceComponent{})
+			w.AddEntity(e)
+		}
+	}
+	Bench(b, preload, setup)
+}
+
+func BenchmarkComponentDouble(b *testing.B) {
+	preload := func() {}
+	setup := func(w *World) {
+		w.AddSystem(&getComponentSystem{})
+		for i := 0; i < benchmarkComponentCount; i++ {
+			e := NewEntity([]string{"getComponentSystem"})
+			e.AddComponent(&SpaceComponent{})
+			e.AddComponent(&RenderComponent{})
+			w.AddEntity(e)
+		}
+	}
+	Bench(b, preload, setup)
+}
+
+type getComponentSystemFast struct {
+	*System
+}
+
+func (getComponentSystemFast) Type() string {
+	return "getComponentSystemFast"
+}
+
+func (g *getComponentSystemFast) New() {
+	g.System = NewSystem()
+}
+
+func (g *getComponentSystemFast) Update(entity *Entity, dt float32) {
+	var sp *SpaceComponent
+	var ok bool
+	if sp, ok = entity.ComponentFast(sp).(*SpaceComponent); !ok {
+		return
+	}
+	// Not needed, but we need to ensure it gets compiled correctly
+	if sp == nil {
+		return
+	}
+
+	if len(entity.components) != 2 {
+		return
+	}
+
+	var ren *RenderComponent
+	if ren, ok = entity.ComponentFast(ren).(*RenderComponent); !ok {
+		return
+	}
+	// Not needed, but we need to ensure it gets compiled correctly
+	if ren == nil {
+		return
+	}
+}
+
+func BenchmarkComponentFast(b *testing.B) {
+	preload := func() {}
+	setup := func(w *World) {
+		w.AddSystem(&getComponentSystemFast{})
+		for i := 0; i < benchmarkComponentCount; i++ {
+			e := NewEntity([]string{"getComponentSystemFast"})
+			e.AddComponent(&SpaceComponent{})
+			w.AddEntity(e)
+		}
+	}
+	Bench(b, preload, setup)
+}
+
+func BenchmarkComponentFastDouble(b *testing.B) {
+	preload := func() {}
+	setup := func(w *World) {
+		w.AddSystem(&getComponentSystemFast{})
+		for i := 0; i < benchmarkComponentCount; i++ {
+			e := NewEntity([]string{"getComponentSystemFast"})
+			e.AddComponent(&SpaceComponent{})
+			e.AddComponent(&RenderComponent{})
+			w.AddEntity(e)
+		}
+	}
+	Bench(b, preload, setup)
+}

--- a/pause.go
+++ b/pause.go
@@ -4,7 +4,7 @@ package engi
 // system-wide pauses.
 type UnpauseComponent struct{}
 
-func (UnpauseComponent) Type() string {
+func (*UnpauseComponent) Type() string {
 	return "UnpauseComponent"
 }
 

--- a/render.go
+++ b/render.go
@@ -59,7 +59,7 @@ func (r *RenderComponent) SetPriority(p PriorityLevel) {
 	r.priority = p
 }
 
-func (RenderComponent) Type() string {
+func (*RenderComponent) Type() string {
 	return "RenderComponent"
 }
 
@@ -116,11 +116,18 @@ func (rs *RenderSystem) Post() {
 		}
 		// Then render everything for this level
 		for _, entity := range rs.renders[i] {
-			var render *RenderComponent
-			var space *SpaceComponent
+			var (
+				render *RenderComponent
+				space  *SpaceComponent
+				ok     bool
+			)
 
-			if !entity.Component(&render) || !entity.Component(&space) {
-				continue
+			if render, ok = entity.ComponentFast(render).(*RenderComponent); !ok {
+				continue // with other entities
+			}
+
+			if space, ok = entity.ComponentFast(space).(*SpaceComponent); !ok {
+				continue // with other entities
 			}
 
 			render.Display.Render(batch, render, space)
@@ -140,7 +147,9 @@ func (rs *RenderSystem) Update(entity *Entity, dt float32) {
 	}
 
 	var render *RenderComponent
-	if !entity.Component(&render) {
+	var ok bool
+
+	if render, ok = entity.ComponentFast(render).(*RenderComponent); !ok {
 		return
 	}
 

--- a/world.go
+++ b/world.go
@@ -89,10 +89,9 @@ func (w *World) update(dt float32) {
 	w.pre()
 
 	var unp *UnpauseComponent
-	systemsList := w.Systems()
 
 	complChan := make(chan struct{})
-	for _, system := range systemsList {
+	for _, system := range w.Systems() {
 		if headless && system.SkipOnHeadless() {
 			continue // so skip it
 		}
@@ -107,7 +106,7 @@ func (w *World) update(dt float32) {
 		if w.serial || count < 20 {
 			for _, entity := range entities {
 				if w.paused && !entity.Component(&unp) {
-					continue // so skip it
+					continue // with other entities
 				}
 				system.Update(entity, dt)
 			}
@@ -115,7 +114,7 @@ func (w *World) update(dt float32) {
 			for _, entity := range entities {
 				if w.paused && !entity.Component(&unp) {
 					count--
-					continue // so skip it
+					continue // with other entities
 				}
 				go func(entity *Entity) {
 					system.Update(entity, dt)

--- a/world_test.go
+++ b/world_test.go
@@ -23,9 +23,9 @@ func TestAddEntity(t *testing.T) {
 	headless = true
 	world := World{}
 	world.new()
-	entityOne := NewEntity([]string{})
+	entityOne := NewEntity(nil)
 	world.AddEntity(entityOne)
-	entityTwo := NewEntity([]string{})
+	entityTwo := NewEntity(nil)
 	world.AddEntity(entityTwo)
 	if len(world.Entities()) != 2 {
 		log.Printf("Entities not added.  %d != 2: %+v\n", len(world.Entities()), world.Entities())
@@ -55,7 +55,7 @@ func TestAddComponent(t *testing.T) {
 	world.AddSystem(&TestSystem{})
 	entity := NewEntity([]string{"TestSystem"})
 	world.AddEntity(entity)
-	component := SpaceComponent{Position: Point{0, 10}, Width: 100, Height: 100}
+	component := &SpaceComponent{Position: Point{0, 10}, Width: 100, Height: 100}
 	entity.AddComponent(component)
 	if len(entity.components) != 1 {
 		t.Fail()


### PR DESCRIPTION
It shows that using `ComponentFast` a lot faster.

```
BenchmarkComponent-8          	   20000	    155262 ns/op	   16200 B/op	    1002 allocs/op
BenchmarkComponentDouble-8    	   10000	    266979 ns/op	   24200 B/op	    2002 allocs/op
BenchmarkComponentFast-8      	   50000	     70341 ns/op	    8200 B/op	       2 allocs/op
BenchmarkComponentFastDouble-8	   30000	     86215 ns/op	    8200 B/op	       2 allocs/op
```

* The benchmark is: how long does it take for one iteration / frame to run, with 1000 `Entity`s tied to one `System`, which either uses `GetComponent`, or `ComponentFast` to get its `Component`s. 
    * note that this means that the `ns/op` also includes other stuff, unrelated to `GetComponent`, such as iterating over all `Entity`s. 
* The `Double` postfix means that it tries to parse two components, i.e.: `SpaceComponent` and `RenderComponent`.

~~The syntax of the `ComponentFast` is not yet what I'd want, but I'm not yet sure what I want it to be.~~