### PR TITLE
Fixed empty entries in World.Entities

### DIFF
--- a/world.go
+++ b/world.go
@@ -56,7 +56,7 @@ func (w *World) AddSystem(system Systemer) {
 }
 
 func (w *World) Entities() []*Entity {
-	entities := make([]*Entity, len(w.entities))
+	entities := make([]*Entity, 0, len(w.entities))
 	for _, v := range w.entities {
 		entities = append(entities, v)
 	}


### PR DESCRIPTION
`append` already increases length and capacity, so if you create something with length `100`, and then `append` 100 things to it, then it ends up with a length of `200`. 