### PR TITLE
Added RunInParallel

### DIFF
--- a/collision.go
+++ b/collision.go
@@ -64,6 +64,10 @@ func (cs *CollisionSystem) New() {
 	cs.System = NewSystem()
 }
 
+func (cs *CollisionSystem) RunInParallel() bool {
+	return len(cs.entities) > 40 // turning point for CollisionSystem
+}
+
 func (cs *CollisionSystem) Update(entity *Entity, dt float32) {
 	var (
 		space     *SpaceComponent

--- a/system.go
+++ b/system.go
@@ -20,6 +20,7 @@ type Systemer interface {
 	RemoveEntity(entity *Entity)
 	SkipOnHeadless() bool
 	SetWorld(*World)
+	RunInParallel() bool
 }
 
 type System struct {
@@ -42,6 +43,7 @@ func (s System) Post() {}
 func (s System) Priority() int {
 	return 0
 }
+func (s System) RunInParallel() bool { return false }
 
 func (s System) Entities() []*Entity {
 	list := make([]*Entity, len(s.entities))

--- a/world.go
+++ b/world.go
@@ -103,7 +103,7 @@ func (w *World) update(dt float32) {
 
 		// Concurrency performance maximized at 20+ entities
 		// Performance tuning should be conducted for entity updates
-		if w.serial || count < 20 {
+		if w.serial || count < 20 || !system.RunInParallel() {
 			for _, entity := range entities {
 				if w.paused && !entity.Component(&unp) {
 					continue // with other entities


### PR DESCRIPTION
`Systemer` now includes a function `RunInParallel`, which indicates whether or not the `Entity`s should be processed in Parallel. 

`CollisionSystem` only benefits from `RunInParallel`, if it has more than 40 entities. This is because `CollisionSystem` is quite fast when there's less than 40 entities, and the overhead of starting goroutines is more. 

Each `System` has its own turning point, which can be defined without much effort (see code). 