### PR TITLE
Sorting Systems in World

### DIFF
--- a/system.go
+++ b/system.go
@@ -64,3 +64,15 @@ func (s *System) RemoveEntity(entity *Entity) {
 func (s System) SkipOnHeadless() bool {
 	return s.ShouldSkipOnHeadless
 }
+
+type Systemers []Systemer
+
+func (s Systemers) Len() int {
+	return len(s)
+}
+func (s Systemers) Less(i, j int) bool {
+	return s[i].Priority() < s[j].Priority()
+}
+func (s Systemers) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}

--- a/world.go
+++ b/world.go
@@ -1,10 +1,13 @@
 package engi
 
-import "runtime"
+import (
+	"runtime"
+	"sort"
+)
 
 type World struct {
 	entities map[string]*Entity
-	systems  []Systemer
+	systems  Systemers
 
 	defaultBatch *Batch
 	hudBatch     *Batch
@@ -62,6 +65,7 @@ func (w *World) RemoveEntity(entity *Entity) {
 func (w *World) AddSystem(system Systemer) {
 	system.New(w)
 	w.systems = append(w.systems, system)
+	sort.Sort(w.systems)
 }
 
 func (w *World) Entities() []*Entity {


### PR DESCRIPTION
When adding a `System` to `World`, it's appended
to the end, and then a quicksort algorithm is used
to sort it according to `System.Priority()`.

Fixes #105. 