### PR TITLE
Fixed some global variables wrt Scene

### DIFF
--- a/ecs/world.go
+++ b/ecs/world.go
@@ -84,6 +84,15 @@ func (w *World) Systems() []Systemer {
 	return w.systems
 }
 
+func (w *World) HasSystem(systemType string) bool {
+	for _, s := range w.systems {
+		if s.Type() == systemType {
+			return true
+		}
+	}
+	return false
+}
+
 // Update is called on each frame, with dt being the time difference in seconds since the last Update call
 func (w *World) Update(dt float32) {
 	complChan := make(chan struct{})

--- a/engi.go
+++ b/engi.go
@@ -6,6 +6,7 @@ package engi
 
 import (
 	"fmt"
+
 	"github.com/paked/engi/ecs"
 	"github.com/paked/webgl"
 )
@@ -14,12 +15,12 @@ var (
 	Time        *Clock
 	Files       *Loader
 	Gl          *webgl.Context
-	Mailbox     MessageManager
-	cam         *cameraSystem
 	WorldBounds AABB
 
 	currentWorld *ecs.World
 	currentScene Scene
+	Mailbox      *MessageManager
+	cam          *cameraSystem
 
 	scaleOnResize   = false
 	fpsLimit        = 120

--- a/engi_glfw.go
+++ b/engi_glfw.go
@@ -55,6 +55,8 @@ func run(defaultScene Scene, title string, width, height int, fullscreen bool) {
 
 	Arrow = glfw.CreateStandardCursor(int(glfw.ArrowCursor))
 	Hand = glfw.CreateStandardCursor(int(glfw.HandCursor))
+	IBeam = glfw.CreateStandardCursor(int(glfw.IBeamCursor))
+	Crosshair = glfw.CreateStandardCursor(int(glfw.CrosshairCursor))
 
 	monitor := glfw.GetPrimaryMonitor()
 	mode := monitor.GetVideoMode()
@@ -136,8 +138,12 @@ func run(defaultScene Scene, title string, width, height int, fullscreen bool) {
 			gameWidth, gameHeight = float32(widthInt), float32(heightInt)
 
 			// Update default batch
-			for _, world := range worlds {
-				for _, s := range world.Systems() {
+			for _, scene := range scenes {
+				if scene.world == nil {
+					continue // with other scenes
+				}
+
+				for _, s := range scene.world.Systems() {
 					if render, ok := s.(*RenderSystem); ok {
 						render.defaultBatch.SetProjection(gameWidth, gameHeight)
 					}
@@ -146,8 +152,12 @@ func run(defaultScene Scene, title string, width, height int, fullscreen bool) {
 		}
 
 		// Update HUD batch
-		for _, world := range worlds {
-			for _, s := range world.Systems() {
+		for _, scene := range scenes {
+			if scene.world == nil {
+				continue // with other scenes
+			}
+
+			for _, s := range scene.world.Systems() {
 				if render, ok := s.(*RenderSystem); ok {
 					render.hudBatch.SetProjection(windowWidth, windowHeight)
 				}

--- a/render.go
+++ b/render.go
@@ -5,8 +5,9 @@
 package engi
 
 import (
-	"github.com/paked/engi/ecs"
 	"image/color"
+
+	"github.com/paked/engi/ecs"
 )
 
 const (
@@ -88,12 +89,6 @@ func (rs *RenderSystem) New(w *ecs.World) {
 	if !headless {
 		rs.defaultBatch = NewBatch(Width(), Height(), batchVert, batchFrag)
 		rs.hudBatch = NewBatch(Width(), Height(), hudVert, hudFrag)
-	}
-
-	// Set cameraSystem if doesn't already exist
-	if cam == nil {
-		cam = &cameraSystem{}
-		w.AddSystem(cam)
 	}
 
 	Mailbox.Listen("renderChangeMessage", func(m Message) {


### PR DESCRIPTION
Fixes #126 and fixes #128.

Global variables are now updated on Scene creation (whenever
we initialize a new World instance). These values are saved
in a sceneWrapper, so we don't always have to reinitialize.

CameraSystem is now set on Scene creation, since this was
hard to do within RenderSystem (as it is Scene-specific).

Ready for review @paked. 