### PR TITLE
fix golang/x/mobile/exp/audio call failed

### DIFF
--- a/audio_player.go
+++ b/audio_player.go
@@ -237,14 +237,14 @@ func (p *Player) prepare(background bool, offset int64, force bool) error {
 
 	p.mu.Lock()
 	if len(p.bufs) > 0 {
-		p.source.UnqueueBuffers(p.bufs...)
-		al.DeleteBuffers(p.bufs...)
+		p.source.UnqueueBuffers(p.bufs)
+		al.DeleteBuffers(p.bufs)
 	}
 	p.sizeBytes = size
 	p.bufs = bufs
 	p.prep = true
 	if len(bufs) > 0 {
-		p.source.QueueBuffers(bufs...)
+		p.source.QueueBuffers(bufs)
 	}
 	p.mu.Unlock()
 	return nil
@@ -357,7 +357,7 @@ func (p *Player) Close() error {
 	}
 	p.mu.Lock()
 	if len(p.bufs) > 0 {
-		al.DeleteBuffers(p.bufs...)
+		al.DeleteBuffers(p.bufs)
 	}
 	p.mu.Unlock()
 	p.t.src.Close()


### PR DESCRIPTION
On go 1.5.1, update golang.org/mobile/ to the latest version.
Fix build error, though it still has no sound.
