### PR TITLE
Changed Systemer to System interface

### DIFF
--- a/animation.go
+++ b/animation.go
@@ -71,28 +71,26 @@ func (*AnimationComponent) Type() string {
 }
 
 type AnimationSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (a *AnimationSystem) New(*ecs.World) {
-	a.System = ecs.NewSystem()
-}
+func (a *AnimationSystem) New(*ecs.World) {}
 
-func (AnimationSystem) Type() string {
-	return "AnimationSystem"
-}
+func (*AnimationSystem) Type() string { return "AnimationSystem" }
+func (*AnimationSystem) Pre()         {}
+func (*AnimationSystem) Post()        {}
 
-func (a *AnimationSystem) Update(e *ecs.Entity, dt float32) {
+func (a *AnimationSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var (
 		ac *AnimationComponent
 		r  *RenderComponent
 		ok bool
 	)
 
-	if ac, ok = e.ComponentFast(ac).(*AnimationComponent); !ok {
+	if ac, ok = entity.ComponentFast(ac).(*AnimationComponent); !ok {
 		return
 	}
-	if r, ok = e.ComponentFast(r).(*RenderComponent); !ok {
+	if r, ok = entity.ComponentFast(r).(*RenderComponent); !ok {
 		return
 	}
 

--- a/audio.go
+++ b/audio.go
@@ -26,17 +26,15 @@ func (*AudioComponent) Type() string {
 
 // AudioSystem is a System that allows for sound effects and / or music
 type AudioSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 	HeightModifier float32
 }
 
-func (AudioSystem) Type() string {
-	return "AudioSystem"
-}
+func (*AudioSystem) Type() string { return "AudioSystem" }
+func (*AudioSystem) Pre()         {}
+func (*AudioSystem) Post()        {}
 
 func (as *AudioSystem) New(*ecs.World) {
-	as.System = ecs.NewSystem()
-
 	if as.HeightModifier == 0 {
 		as.HeightModifier = defaultHeightModifier
 	}
@@ -58,7 +56,7 @@ func (as *AudioSystem) New(*ecs.World) {
 	})
 }
 
-func (as *AudioSystem) Update(entity *ecs.Entity, dt float32) {
+func (as *AudioSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var ac *AudioComponent
 	var ok bool
 	if ac, ok = entity.ComponentFast(ac).(*AudioComponent); !ok {

--- a/audio_windows.go
+++ b/audio_windows.go
@@ -24,7 +24,7 @@ func (*AudioComponent) Type() string {
 
 // AudioSystem is a System that allows for sound effects and / or music
 type AudioSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 	HeightModifier float32
 }
 
@@ -33,9 +33,7 @@ func (AudioSystem) Type() string {
 }
 
 func (as *AudioSystem) New(*ecs.World) {
-	as.System = ecs.NewSystem()
-
 	log.Println("Warning: audio is not yet implemented on Windows")
 }
 
-func (as *AudioSystem) Update(entity *ecs.Entity, dt float32) {}
+func (as *AudioSystem) UpdateEntity(entity *ecs.Entity, dt float32) {}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 type NilSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ns *NilSystem) New(*ecs.World) {
-	ns.System = ecs.NewSystem()
-}
+func (ns *NilSystem) New(*ecs.World) {}
 
-func (*NilSystem) Update(*ecs.Entity, float32) {}
+func (*NilSystem) Pre()                              {}
+func (*NilSystem) Post()                             {}
+func (*NilSystem) UpdateEntity(*ecs.Entity, float32) {}
 
 func (*NilSystem) Type() string {
 	return "NilSystem"

--- a/camera_test.go
+++ b/camera_test.go
@@ -1,18 +1,31 @@
 package engi
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/paked/engi/ecs"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestCameraMoveX(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
+func initialize() {
+	Mailbox = &MessageManager{}
 	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
+	currentWorld = &ecs.World{}
+
+	cam = &cameraSystem{}
+	cam.New(currentWorld)
+}
+
+type CameraTestScene struct{}
+
+func (*CameraTestScene) Preload()         {}
+func (*CameraTestScene) Setup(*ecs.World) {}
+func (*CameraTestScene) Show()            {}
+func (*CameraTestScene) Hide()            {}
+func (*CameraTestScene) Type() string     { return "CameraTestScene" }
+
+func TestCameraMoveX(t *testing.T) {
+	initialize()
 
 	currentX := cam.X()
 
@@ -42,11 +55,7 @@ func TestCameraMoveX(t *testing.T) {
 }
 
 func TestCameraMoveY(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
-	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
+	initialize()
 
 	currentY := cam.Y()
 
@@ -76,10 +85,7 @@ func TestCameraMoveY(t *testing.T) {
 }
 
 func TestCameraZoom(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
+	initialize()
 
 	currentZ := cam.Z()
 
@@ -109,11 +115,7 @@ func TestCameraZoom(t *testing.T) {
 }
 
 func TestCameraMoveToX(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
-	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
+	initialize()
 
 	currentX := cam.X()
 
@@ -128,11 +130,7 @@ func TestCameraMoveToX(t *testing.T) {
 }
 
 func TestCameraMoveToY(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
-	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
+	initialize()
 
 	currentY := cam.Y()
 
@@ -147,10 +145,7 @@ func TestCameraMoveToY(t *testing.T) {
 }
 
 func TestCameraZoomTo(t *testing.T) {
-	w := &ecs.World{}
-	w.New()
-	cam := &cameraSystem{}
-	cam.New(w)
+	initialize()
 
 	currentZ := cam.Z()
 

--- a/collision.go
+++ b/collision.go
@@ -1,9 +1,10 @@
 package engi
 
 import (
-	"github.com/paked/engi/ecs"
 	"log"
 	"math"
+
+	"github.com/paked/engi/ecs"
 )
 
 type AABB struct {
@@ -64,18 +65,21 @@ func (collision CollisionMessage) Type() string {
 }
 
 type CollisionSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (cs *CollisionSystem) New(*ecs.World) {
-	cs.System = ecs.NewSystem()
-}
+func (*CollisionSystem) Type() string { return "CollisionSystem" }
+func (*CollisionSystem) Pre()         {}
+func (*CollisionSystem) Post()        {}
+
+func (cs *CollisionSystem) New(*ecs.World) {}
 
 func (cs *CollisionSystem) RunInParallel() bool {
-	return len(cs.Entities()) > 40 // turning point for CollisionSystem
+	// TODO: this function isn't called/used any more ...
+	return len(cs.Entities) > 40 // turning point for CollisionSystem
 }
 
-func (cs *CollisionSystem) Update(entity *ecs.Entity, dt float32) {
+func (cs *CollisionSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var (
 		space     *SpaceComponent
 		collision *CollisionComponent
@@ -99,7 +103,7 @@ func (cs *CollisionSystem) Update(entity *ecs.Entity, dt float32) {
 		otherCollision *CollisionComponent
 	)
 
-	for _, other := range cs.Entities() {
+	for _, other := range cs.Entities {
 		if other.ID() != entity.ID() {
 			if otherSpace, ok = other.ComponentFast(otherSpace).(*SpaceComponent); !ok {
 				return
@@ -132,10 +136,6 @@ func (cs *CollisionSystem) Update(entity *ecs.Entity, dt float32) {
 			}
 		}
 	}
-}
-
-func (*CollisionSystem) Type() string {
-	return "CollisionSystem"
 }
 
 func IsIntersecting(rect1 AABB, rect2 AABB) bool {

--- a/demos/animation/anim.go
+++ b/demos/animation/anim.go
@@ -65,18 +65,16 @@ func (game *GameWorld) CreateEntity(point *engi.Point, spriteSheet *engi.Sprites
 }
 
 type ControlSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ControlSystem) Type() string {
-	return "ControlSystem"
-}
+func (*ControlSystem) Type() string { return "ControlSystem" }
+func (*ControlSystem) Pre()         {}
+func (*ControlSystem) Post()        {}
 
-func (c *ControlSystem) New(*ecs.World) {
-	c.System = ecs.NewSystem()
-}
+func (c *ControlSystem) New(*ecs.World) {}
 
-func (c *ControlSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ControlSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var a *engi.AnimationComponent
 
 	if !entity.Component(&a) {

--- a/demos/animation/anim.go
+++ b/demos/animation/anim.go
@@ -36,7 +36,7 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	w.AddSystem(&engi.RenderSystem{})
 	w.AddSystem(&engi.AnimationSystem{})
 	w.AddSystem(&ControlSystem{})
-	w.AddSystem(engi.NewMouseZoomer(zoomSpeed))
+	w.AddSystem(&engi.MouseZoomer{zoomSpeed})
 
 	spriteSheet := engi.NewSpritesheetFromFile("hero.png", 150, 150)
 

--- a/demos/edgescroller/escroller.go
+++ b/demos/edgescroller/escroller.go
@@ -59,7 +59,7 @@ func (game *Game) Setup(w *ecs.World) {
 	w.AddSystem(&engi.RenderSystem{})
 
 	// The most important line in this whole demo:
-	w.AddSystem(engi.NewEdgeScroller(scrollSpeed, edgeMargin))
+	w.AddSystem(&engi.EdgeScroller{scrollSpeed, edgeMargin})
 
 	// Create the background; this way we'll see when we actually scroll
 	err := w.AddEntity(generateBackground())

--- a/demos/falling/falling.go
+++ b/demos/falling/falling.go
@@ -117,7 +117,7 @@ func (rock *RockSpawnSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 }
 
 func NewRock(position engi.Point) *ecs.Entity {
-	rock := ecs.NewEntity([]string{"RenderSystem", "FallingSystem", "CollisionSystem", "SpeedSystem"})
+	rock := ecs.NewEntity([]string{"RenderSystem", "FallingSystem", "CollisionSystem"})
 
 	texture := engi.Files.Image("rock.png")
 	render := engi.NewRenderComponent(texture, engi.Point{4, 4}, "rock")
@@ -136,12 +136,8 @@ type FallingSystem struct {
 }
 
 func (*FallingSystem) Type() string { return "FallingSystem" }
-func (*FallingSystem) Pre()         {}
-func (*FallingSystem) Post()        {}
 
-func (fs *FallingSystem) New(*ecs.World) {
-	//engi.Mailbox.Listen("CollisionMessage", fs)
-}
+func (fs *FallingSystem) New(*ecs.World) {}
 
 func (fs *FallingSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
@@ -156,8 +152,6 @@ type DeathSystem struct {
 }
 
 func (*DeathSystem) Type() string { return "DeathSystem" }
-func (*DeathSystem) Pre()         {}
-func (*DeathSystem) Post()        {}
 
 func (ds *DeathSystem) New(*ecs.World) {
 	// Subscribe to ScoreMessage
@@ -170,9 +164,7 @@ func (ds *DeathSystem) New(*ecs.World) {
 	})
 }
 
-func (fs *DeathSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
-
-}
+func (fs *DeathSystem) UpdateEntity(entity *ecs.Entity, dt float32) {}
 
 func (fs *DeathSystem) Receive(message engi.Message) {
 	collision, isCollision := message.(engi.CollisionMessage)

--- a/demos/falling/falling.go
+++ b/demos/falling/falling.go
@@ -53,18 +53,16 @@ func (*Game) Show()        {}
 func (*Game) Type() string { return "Game" }
 
 type ControlSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (control *ControlSystem) New(*ecs.World) {
-	control.System = ecs.NewSystem()
-}
+func (*ControlSystem) Type() string { return "ControlSystem" }
+func (*ControlSystem) Pre()         {}
+func (*ControlSystem) Post()        {}
 
-func (ControlSystem) Type() string {
-	return "ControlSystem"
-}
+func (control *ControlSystem) New(*ecs.World) {}
 
-func (control *ControlSystem) Update(entity *ecs.Entity, dt float32) {
+func (control *ControlSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
 	if !entity.Component(&space) {
 		return
@@ -90,21 +88,20 @@ func (control *ControlSystem) Update(entity *ecs.Entity, dt float32) {
 }
 
 type RockSpawnSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 
 	world *ecs.World
 }
 
-func (RockSpawnSystem) Type() string {
-	return "RockSpawnSystem"
-}
+func (*RockSpawnSystem) Type() string { return "RockSpawnSystem" }
+func (*RockSpawnSystem) Pre()         {}
+func (*RockSpawnSystem) Post()        {}
 
 func (rock *RockSpawnSystem) New(w *ecs.World) {
-	rock.System = ecs.NewSystem()
 	rock.world = w
 }
 
-func (rock *RockSpawnSystem) Update(entity *ecs.Entity, dt float32) {
+func (rock *RockSpawnSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	// 4% change of spawning a rock each frame
 	if rand.Float32() < .96 {
 		return
@@ -134,20 +131,18 @@ func NewRock(position engi.Point) *ecs.Entity {
 }
 
 type FallingSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
+
+func (*FallingSystem) Type() string { return "FallingSystem" }
+func (*FallingSystem) Pre()         {}
+func (*FallingSystem) Post()        {}
 
 func (fs *FallingSystem) New(*ecs.World) {
-	fs.System = ecs.NewSystem()
 	//engi.Mailbox.Listen("CollisionMessage", fs)
-
 }
 
-func (FallingSystem) Type() string {
-	return "FallingSystem"
-}
-
-func (fs *FallingSystem) Update(entity *ecs.Entity, dt float32) {
+func (fs *FallingSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
 	if !entity.Component(&space) {
 		return
@@ -156,11 +151,14 @@ func (fs *FallingSystem) Update(entity *ecs.Entity, dt float32) {
 }
 
 type DeathSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
+func (*DeathSystem) Type() string { return "DeathSystem" }
+func (*DeathSystem) Pre()         {}
+func (*DeathSystem) Post()        {}
+
 func (ds *DeathSystem) New(*ecs.World) {
-	ds.System = ecs.NewSystem()
 	// Subscribe to ScoreMessage
 	engi.Mailbox.Listen("ScoreMessage", func(message engi.Message) {
 		collision, isCollision := message.(engi.CollisionMessage)
@@ -169,14 +167,9 @@ func (ds *DeathSystem) New(*ecs.World) {
 			log.Println("DEAD")
 		}
 	})
-
 }
 
-func (DeathSystem) Type() string {
-	return "DeathSystem"
-}
-
-func (fs *DeathSystem) Update(entity *ecs.Entity, dt float32) {
+func (fs *DeathSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 
 }
 

--- a/demos/headless/headless.go
+++ b/demos/headless/headless.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
+	"image/color"
 	"log"
 	"math/rand"
 	"sync"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
-	"image/color"
 )
 
 type PongGame struct{}
@@ -90,11 +90,14 @@ func (*PongGame) Show()        {}
 func (*PongGame) Type() string { return "PongGame" }
 
 type SpeedSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
+func (*SpeedSystem) Type() string { return "SpeedSystem" }
+func (*SpeedSystem) Pre()         {}
+func (*SpeedSystem) Post()        {}
+
 func (ms *SpeedSystem) New(*ecs.World) {
-	ms.System = ecs.NewSystem()
 	engi.Mailbox.Listen("CollisionMessage", func(message engi.Message) {
 		log.Println("collision")
 		collision, isCollision := message.(engi.CollisionMessage)
@@ -109,11 +112,7 @@ func (ms *SpeedSystem) New(*ecs.World) {
 	})
 }
 
-func (*SpeedSystem) Type() string {
-	return "SpeedSystem"
-}
-
-func (ms *SpeedSystem) Update(entity *ecs.Entity, dt float32) {
+func (ms *SpeedSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var speed *SpeedComponent
 	var space *engi.SpaceComponent
 	if !entity.Component(&speed) || !entity.Component(&space) {
@@ -134,18 +133,16 @@ func (*SpeedComponent) Type() string {
 }
 
 type BallSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (bs *BallSystem) New(*ecs.World) {
-	bs.System = ecs.NewSystem()
-}
+func (bs *BallSystem) New(*ecs.World) {}
 
-func (BallSystem) Type() string {
-	return "BallSystem"
-}
+func (*BallSystem) Type() string { return "BallSystem" }
+func (*BallSystem) Pre()         {}
+func (*BallSystem) Post()        {}
 
-func (bs *BallSystem) Update(entity *ecs.Entity, dt float32) {
+func (bs *BallSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
 	var speed *SpeedComponent
 	if !entity.Component(&space) || !entity.Component(&speed) {
@@ -182,17 +179,16 @@ func (bs *BallSystem) Update(entity *ecs.Entity, dt float32) {
 }
 
 type ControlSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ControlSystem) Type() string {
-	return "ControlSystem"
-}
-func (c *ControlSystem) New(*ecs.World) {
-	c.System = ecs.NewSystem()
-}
+func (*ControlSystem) Type() string { return "ControlSystem" }
+func (*ControlSystem) Pre()         {}
+func (*ControlSystem) Post()        {}
 
-func (c *ControlSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ControlSystem) New(*ecs.World) {}
+
+func (c *ControlSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	//Check scheme
 	// -Move entity based on that
 	var control *ControlComponent
@@ -230,19 +226,18 @@ func (*ControlComponent) Type() string {
 }
 
 type ScoreSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 	PlayerOneScore, PlayerTwoScore int
 	upToDate                       bool
 	scoreLock                      sync.RWMutex
 }
 
-func (ScoreSystem) Type() string {
-	return "ScoreSystem"
-}
+func (*ScoreSystem) Type() string { return "ScoreSystem" }
+func (*ScoreSystem) Pre()         {}
+func (*ScoreSystem) Post()        {}
 
 func (sc *ScoreSystem) New(*ecs.World) {
 	sc.upToDate = true
-	sc.System = ecs.NewSystem()
 	engi.Mailbox.Listen("ScoreMessage", func(message engi.Message) {
 		scoreMessage, isScore := message.(ScoreMessage)
 		if !isScore {
@@ -261,7 +256,7 @@ func (sc *ScoreSystem) New(*ecs.World) {
 	})
 }
 
-func (c *ScoreSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ScoreSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var render *engi.RenderComponent
 	var space *engi.SpaceComponent
 

--- a/demos/headless/headless.go
+++ b/demos/headless/headless.go
@@ -95,8 +95,6 @@ type SpeedSystem struct {
 }
 
 func (*SpeedSystem) Type() string { return "SpeedSystem" }
-func (*SpeedSystem) Pre()         {}
-func (*SpeedSystem) Post()        {}
 
 func (ms *SpeedSystem) New(*ecs.World) {
 	engi.Mailbox.Listen("CollisionMessage", func(message engi.Message) {
@@ -140,8 +138,6 @@ type BallSystem struct {
 func (bs *BallSystem) New(*ecs.World) {}
 
 func (*BallSystem) Type() string { return "BallSystem" }
-func (*BallSystem) Pre()         {}
-func (*BallSystem) Post()        {}
 
 func (bs *BallSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
@@ -184,8 +180,6 @@ type ControlSystem struct {
 }
 
 func (*ControlSystem) Type() string { return "ControlSystem" }
-func (*ControlSystem) Pre()         {}
-func (*ControlSystem) Post()        {}
 
 func (c *ControlSystem) New(*ecs.World) {}
 
@@ -234,8 +228,6 @@ type ScoreSystem struct {
 }
 
 func (*ScoreSystem) Type() string { return "ScoreSystem" }
-func (*ScoreSystem) Pre()         {}
-func (*ScoreSystem) Post()        {}
 
 func (sc *ScoreSystem) New(*ecs.World) {
 	sc.upToDate = true

--- a/demos/hello/hello.go
+++ b/demos/hello/hello.go
@@ -50,20 +50,18 @@ func (*GameWorld) Show()        {}
 func (*GameWorld) Type() string { return "GameWorld" }
 
 type ScaleSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ScaleSystem) Type() string {
-	return "ScaleSystem"
-}
+func (*ScaleSystem) Type() string { return "ScaleSystem" }
+func (*ScaleSystem) Pre()         {}
+func (*ScaleSystem) Post()        {}
 
-func (s *ScaleSystem) New(*ecs.World) {
-	s.System = ecs.NewSystem()
-}
+func (s *ScaleSystem) New(*ecs.World) {}
 
-func (c *ScaleSystem) Update(e *ecs.Entity, dt float32) {
+func (c *ScaleSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var render *engi.RenderComponent
-	if !e.Component(&render) {
+	if !entity.Component(&render) {
 		return
 	}
 	var mod float32

--- a/demos/hello/hello.go
+++ b/demos/hello/hello.go
@@ -55,8 +55,6 @@ type ScaleSystem struct {
 }
 
 func (*ScaleSystem) Type() string { return "ScaleSystem" }
-func (*ScaleSystem) Pre()         {}
-func (*ScaleSystem) Post()        {}
 
 func (s *ScaleSystem) New(*ecs.World) {}
 

--- a/demos/hide/hide.go
+++ b/demos/hide/hide.go
@@ -50,8 +50,6 @@ type HideSystem struct {
 }
 
 func (*HideSystem) Type() string { return "HideSystem" }
-func (*HideSystem) Pre()         {}
-func (*HideSystem) Post()        {}
 
 func (s *HideSystem) New(*ecs.World) {}
 

--- a/demos/hide/hide.go
+++ b/demos/hide/hide.go
@@ -45,20 +45,18 @@ func (*GameWorld) Show()        {}
 func (*GameWorld) Type() string { return "GameWorld" }
 
 type HideSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (HideSystem) Type() string {
-	return "HideSystem"
-}
+func (*HideSystem) Type() string { return "HideSystem" }
+func (*HideSystem) Pre()         {}
+func (*HideSystem) Post()        {}
 
-func (s *HideSystem) New(*ecs.World) {
-	s.System = ecs.NewSystem()
-}
+func (s *HideSystem) New(*ecs.World) {}
 
-func (c *HideSystem) Update(e *ecs.Entity, dt float32) {
+func (c *HideSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var render *engi.RenderComponent
-	if !e.Component(&render) {
+	if !entity.Component(&render) {
 		return
 	}
 	if rand.Int()%10 == 0 {

--- a/demos/hud/hud.go
+++ b/demos/hud/hud.go
@@ -82,7 +82,7 @@ func (game *Game) Setup(w *ecs.World) {
 
 	// Adding KeyboardScroller so we can actually see the difference between background and HUD when scrolling
 	w.AddSystem(engi.NewKeyboardScroller(scrollSpeed, engi.W, engi.D, engi.S, engi.A))
-	w.AddSystem(engi.NewMouseZoomer(zoomSpeed))
+	w.AddSystem(&engi.MouseZoomer{zoomSpeed})
 
 	// Create background, so we can see difference between this and HUD
 	err := w.AddEntity(generateBackground())

--- a/demos/mouse/mouse.go
+++ b/demos/mouse/mouse.go
@@ -40,7 +40,7 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	w.AddSystem(&engi.MouseSystem{})
 	w.AddSystem(&engi.RenderSystem{})
 	w.AddSystem(&ControlSystem{})
-	w.AddSystem(engi.NewMouseZoomer(-0.125))
+	w.AddSystem(&engi.MouseZoomer{-0.125})
 
 	err := w.AddEntity(game.CreateEntity())
 	if err != nil {
@@ -63,18 +63,16 @@ func (game *GameWorld) CreateEntity() *ecs.Entity {
 }
 
 type ControlSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ControlSystem) Type() string {
-	return "ControlSystem"
-}
+func (*ControlSystem) Type() string { return "ControlSystem" }
+func (*ControlSystem) Pre()         {}
+func (*ControlSystem) Post()        {}
 
-func (c *ControlSystem) New(*ecs.World) {
-	c.System = ecs.NewSystem()
-}
+func (c *ControlSystem) New(*ecs.World) {}
 
-func (c *ControlSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ControlSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var mouse *engi.MouseComponent
 	if !entity.Component(&mouse) {
 		return
@@ -83,7 +81,7 @@ func (c *ControlSystem) Update(entity *ecs.Entity, dt float32) {
 	if mouse.Enter {
 		engi.SetCursor(engi.Hand)
 	} else if mouse.Leave {
-		engi.SetCursor(engi.Arrow)
+		engi.SetCursor(nil)
 	}
 }
 

--- a/demos/mouse/mouse.go
+++ b/demos/mouse/mouse.go
@@ -67,8 +67,6 @@ type ControlSystem struct {
 }
 
 func (*ControlSystem) Type() string { return "ControlSystem" }
-func (*ControlSystem) Pre()         {}
-func (*ControlSystem) Post()        {}
 
 func (c *ControlSystem) New(*ecs.World) {}
 

--- a/demos/pong/pong.go
+++ b/demos/pong/pong.go
@@ -97,8 +97,6 @@ type SpeedSystem struct {
 }
 
 func (*SpeedSystem) Type() string { return "SpeedSystem" }
-func (*SpeedSystem) Pre()         {}
-func (*SpeedSystem) Post()        {}
 
 func (ms *SpeedSystem) New(*ecs.World) {
 	engi.Mailbox.Listen("CollisionMessage", func(message engi.Message) {
@@ -140,8 +138,6 @@ type BallSystem struct {
 }
 
 func (*BallSystem) Type() string { return "BallSystem" }
-func (*BallSystem) Pre()         {}
-func (*BallSystem) Post()        {}
 
 func (bs *BallSystem) New(*ecs.World) {}
 
@@ -186,8 +182,6 @@ type ControlSystem struct {
 }
 
 func (*ControlSystem) Type() string { return "ControlSystem" }
-func (*ControlSystem) Pre()         {}
-func (*ControlSystem) Post()        {}
 
 func (c *ControlSystem) New(*ecs.World) {}
 
@@ -236,8 +230,6 @@ type ScoreSystem struct {
 }
 
 func (*ScoreSystem) Type() string { return "ScoreSystem" }
-func (*ScoreSystem) Pre()         {}
-func (*ScoreSystem) Post()        {}
 
 func (sc *ScoreSystem) New(*ecs.World) {
 	sc.upToDate = true

--- a/demos/pong/pong.go
+++ b/demos/pong/pong.go
@@ -93,11 +93,14 @@ func (*PongGame) Show()        {}
 func (*PongGame) Type() string { return "PongGame" }
 
 type SpeedSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
+func (*SpeedSystem) Type() string { return "SpeedSystem" }
+func (*SpeedSystem) Pre()         {}
+func (*SpeedSystem) Post()        {}
+
 func (ms *SpeedSystem) New(*ecs.World) {
-	ms.System = ecs.NewSystem()
 	engi.Mailbox.Listen("CollisionMessage", func(message engi.Message) {
 		log.Println("collision")
 		collision, isCollision := message.(engi.CollisionMessage)
@@ -112,11 +115,7 @@ func (ms *SpeedSystem) New(*ecs.World) {
 	})
 }
 
-func (*SpeedSystem) Type() string {
-	return "SpeedSystem"
-}
-
-func (ms *SpeedSystem) Update(entity *ecs.Entity, dt float32) {
+func (ms *SpeedSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var speed *SpeedComponent
 	var space *engi.SpaceComponent
 	if !entity.Component(&speed) || !entity.Component(&space) {
@@ -137,18 +136,16 @@ func (*SpeedComponent) Type() string {
 }
 
 type BallSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (bs *BallSystem) New(*ecs.World) {
-	bs.System = ecs.NewSystem()
-}
+func (*BallSystem) Type() string { return "BallSystem" }
+func (*BallSystem) Pre()         {}
+func (*BallSystem) Post()        {}
 
-func (BallSystem) Type() string {
-	return "BallSystem"
-}
+func (bs *BallSystem) New(*ecs.World) {}
 
-func (bs *BallSystem) Update(entity *ecs.Entity, dt float32) {
+func (bs *BallSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var space *engi.SpaceComponent
 	var speed *SpeedComponent
 	if !entity.Component(&space) || !entity.Component(&speed) {
@@ -185,17 +182,16 @@ func (bs *BallSystem) Update(entity *ecs.Entity, dt float32) {
 }
 
 type ControlSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ControlSystem) Type() string {
-	return "ControlSystem"
-}
-func (c *ControlSystem) New(*ecs.World) {
-	c.System = ecs.NewSystem()
-}
+func (*ControlSystem) Type() string { return "ControlSystem" }
+func (*ControlSystem) Pre()         {}
+func (*ControlSystem) Post()        {}
 
-func (c *ControlSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ControlSystem) New(*ecs.World) {}
+
+func (c *ControlSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	//Check scheme
 	// -Move entity based on that
 	var control *ControlComponent
@@ -233,19 +229,18 @@ func (*ControlComponent) Type() string {
 }
 
 type ScoreSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 	PlayerOneScore, PlayerTwoScore int
 	upToDate                       bool
 	scoreLock                      sync.RWMutex
 }
 
-func (ScoreSystem) Type() string {
-	return "ScoreSystem"
-}
+func (*ScoreSystem) Type() string { return "ScoreSystem" }
+func (*ScoreSystem) Pre()         {}
+func (*ScoreSystem) Post()        {}
 
 func (sc *ScoreSystem) New(*ecs.World) {
 	sc.upToDate = true
-	sc.System = ecs.NewSystem()
 	engi.Mailbox.Listen("ScoreMessage", func(message engi.Message) {
 		scoreMessage, isScore := message.(ScoreMessage)
 		if !isScore {
@@ -264,7 +259,7 @@ func (sc *ScoreSystem) New(*ecs.World) {
 	})
 }
 
-func (c *ScoreSystem) Update(entity *ecs.Entity, dt float32) {
+func (c *ScoreSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var render *engi.RenderComponent
 	var space *engi.SpaceComponent
 

--- a/demos/scenes/scenes.go
+++ b/demos/scenes/scenes.go
@@ -93,23 +93,18 @@ func (*RockScene) Type() string { return "RockScene" }
 
 // SceneSwitcherSystem is a System that actually calls SetScene
 type SceneSwitcherSystem struct {
-	*ecs.System
-
 	NextScene     string
 	WaitTime      time.Duration
 	secondsWaited float32
 }
 
-func (*SceneSwitcherSystem) Type() string {
-	return "SceneSwitcherSystem"
-}
+func (*SceneSwitcherSystem) Type() string             { return "SceneSwitcherSystem" }
+func (*SceneSwitcherSystem) Priority() int            { return 1 }
+func (*SceneSwitcherSystem) AddEntity(*ecs.Entity)    {}
+func (*SceneSwitcherSystem) RemoveEntity(*ecs.Entity) {}
+func (*SceneSwitcherSystem) New(*ecs.World)           {}
 
-func (s *SceneSwitcherSystem) New(*ecs.World) {
-	s.System = ecs.NewSystem()
-	s.System.AddEntity(ecs.NewEntity([]string{s.Type()}))
-}
-
-func (s *SceneSwitcherSystem) Update(e *ecs.Entity, dt float32) {
+func (s *SceneSwitcherSystem) Update(dt float32) {
 	s.secondsWaited += dt
 	if float64(s.secondsWaited) > s.WaitTime.Seconds() {
 		s.secondsWaited = 0
@@ -123,20 +118,18 @@ func (s *SceneSwitcherSystem) Update(e *ecs.Entity, dt float32) {
 
 // ScaleSystem is the System which scales the Entities inside
 type ScaleSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 }
 
-func (ScaleSystem) Type() string {
-	return "ScaleSystem"
-}
+func (*ScaleSystem) Type() string { return "ScaleSystem" }
+func (*ScaleSystem) Pre()         {}
+func (*ScaleSystem) Post()        {}
 
-func (s *ScaleSystem) New(*ecs.World) {
-	s.System = ecs.NewSystem()
-}
+func (s *ScaleSystem) New(*ecs.World) {}
 
-func (c *ScaleSystem) Update(e *ecs.Entity, dt float32) {
+func (c *ScaleSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var render *engi.RenderComponent
-	if !e.Component(&render) {
+	if !entity.Component(&render) {
 		return
 	}
 	var mod float32

--- a/demos/scenes/scenes.go
+++ b/demos/scenes/scenes.go
@@ -123,8 +123,6 @@ type ScaleSystem struct {
 }
 
 func (*ScaleSystem) Type() string { return "ScaleSystem" }
-func (*ScaleSystem) Pre()         {}
-func (*ScaleSystem) Post()        {}
 
 func (s *ScaleSystem) New(*ecs.World) {}
 

--- a/demos/zoom/zoom.go
+++ b/demos/zoom/zoom.go
@@ -56,7 +56,7 @@ func (game *Game) Preload() {}
 func (game *Game) Setup(w *ecs.World) {
 	engi.SetBg(0x222222)
 	w.AddSystem(&engi.RenderSystem{})
-	w.AddSystem(engi.NewMouseZoomer(zoomSpeed))
+	w.AddSystem(&engi.MouseZoomer{zoomSpeed})
 
 	// Create the background; this way we'll see when we actually zoom
 	err := w.AddEntity(generateBackground())

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -4,6 +4,11 @@ import (
 	"reflect"
 )
 
+// Component is a piece of data which belongs to an Entity
+type Component interface {
+	Type() string
+}
+
 // Entity is the E in Entity Component System. It belongs to any amount of
 // Systems, and has a number of Components
 type Entity struct {

--- a/ecs/entity_test.go
+++ b/ecs/entity_test.go
@@ -18,18 +18,16 @@ type MyComponent2 struct{ an int }
 func (*MyComponent2) Type() string { return "MyComponent2" }
 
 type getComponentSystem struct {
-	*System
+	LinearSystem
 }
 
 func (getComponentSystem) Type() string {
 	return "getComponentSystem"
 }
 
-func (g *getComponentSystem) New(*World) {
-	g.System = NewSystem()
-}
+func (g *getComponentSystem) New(*World) {}
 
-func (g *getComponentSystem) Update(entity *Entity, dt float32) {
+func (g *getComponentSystem) UpdateEntity(entity *Entity, dt float32) {
 	var sp *MyComponent1
 	if !entity.Component(&sp) {
 		return
@@ -81,18 +79,16 @@ func BenchmarkComponentDouble(b *testing.B) {
 }
 
 type getComponentSystemFast struct {
-	*System
+	LinearSystem
 }
 
 func (getComponentSystemFast) Type() string {
 	return "getComponentSystemFast"
 }
 
-func (g *getComponentSystemFast) New(*World) {
-	g.System = NewSystem()
-}
+func (g *getComponentSystemFast) New(*World) {}
 
-func (g *getComponentSystemFast) Update(entity *Entity, dt float32) {
+func (g *getComponentSystemFast) UpdateEntity(entity *Entity, dt float32) {
 	var sp *MyComponent1
 	var ok bool
 	if sp, ok = entity.ComponentFast(sp).(*MyComponent1); !ok {

--- a/ecs/entity_test.go
+++ b/ecs/entity_test.go
@@ -25,7 +25,9 @@ func (getComponentSystem) Type() string {
 	return "getComponentSystem"
 }
 
-func (g *getComponentSystem) New(*World) {}
+func (*getComponentSystem) New(*World) {}
+func (*getComponentSystem) Pre()       {}
+func (*getComponentSystem) Post()      {}
 
 func (g *getComponentSystem) UpdateEntity(entity *Entity, dt float32) {
 	var sp *MyComponent1
@@ -86,7 +88,9 @@ func (getComponentSystemFast) Type() string {
 	return "getComponentSystemFast"
 }
 
-func (g *getComponentSystemFast) New(*World) {}
+func (*getComponentSystemFast) New(*World) {}
+func (*getComponentSystemFast) Pre()       {}
+func (*getComponentSystemFast) Post()      {}
 
 func (g *getComponentSystemFast) UpdateEntity(entity *Entity, dt float32) {
 	var sp *MyComponent1

--- a/ecs/linear.go
+++ b/ecs/linear.go
@@ -1,0 +1,97 @@
+package ecs
+
+import (
+	"log"
+	"reflect"
+	"runtime"
+)
+
+// LinearSystem is the default implementation of the System interface, which handles Entities in a linear fashion
+// Implement `LinearSystemFunctions` and inherit this, in order to use it
+type LinearSystem struct {
+	// Entities holds the Entity-references as given by the World
+	Entities []*Entity
+	// RunInParallel indicates whether or not the UpdateEntity function should be called in parallel
+	RunInParallel bool
+	// Prio allows the `World` to order `System`s: the lower the priority-value, the
+	// sooner it will be processed by the `World`.
+	Prio int
+
+	functions LinearSystemFunctions
+}
+
+type LinearSystemFunctions interface {
+	Pre()
+	UpdateEntity(entity *Entity, dt float32)
+	Post()
+}
+
+// Some functions that should be overriden:
+func (s *LinearSystem) New(*World) {}
+func (LinearSystem) Type() string  { return "generic LinearSystem" }
+
+// Update is called by the `World`
+func (s *LinearSystem) Update(dt float32) {
+	s.functions.Pre()
+
+	count := len(s.Entities)
+
+	// Calling them serial / in parallel, depending on the settings
+	if processSystemInSerial || !s.RunInParallel {
+		for _, entity := range s.Entities {
+			s.functions.UpdateEntity(entity, dt)
+		}
+	} else {
+		complChan := make(chan struct{})
+		for _, entity := range s.Entities {
+			go func(entity *Entity) {
+				s.functions.UpdateEntity(entity, dt)
+				complChan <- struct{}{}
+			}(entity)
+		}
+		for ; count > 0; count-- {
+			<-complChan
+		}
+		close(complChan)
+	}
+	s.functions.Post()
+}
+
+func (s *LinearSystem) AddEntity(entity *Entity) {
+	s.Entities = append(s.Entities, entity)
+}
+
+// TODO: not sure if one can still override this?
+func (s *LinearSystem) RemoveEntity(entity *Entity) {
+	for index, e := range s.Entities {
+		if e.ID() == entity.ID() {
+			// Found it, now let's remove it - TODO: make sure this works for the edge case (index+1 being out-of-range?)
+			s.Entities = append(s.Entities[:index], s.Entities[index+1:]...)
+		}
+	}
+}
+
+func (s *LinearSystem) Priority() int {
+	return s.Prio
+}
+
+func (s *LinearSystem) setLinearSystemFunctions(funcs LinearSystemFunctions) {
+	if s != nil {
+		s.functions = funcs
+	} else {
+		log.Println("Warning:", reflect.TypeOf(funcs).String(), "has a pointer-reference to LinearSystem (*ecs.LinearSystem). ")
+	}
+}
+
+type basicSystemSetter interface {
+	setLinearSystemFunctions(LinearSystemFunctions)
+}
+
+var (
+	processSystemInSerial bool
+)
+
+func init() {
+	// Run in serial if there's only 1 core
+	processSystemInSerial = runtime.NumCPU() == 1
+}

--- a/ecs/system.go
+++ b/ecs/system.go
@@ -1,96 +1,37 @@
-// Copyright 2014-2015 Harrison Shoebridge and other contributors.
-// All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
 package ecs
 
-// Component is a piece of data which belongs to an Entity
-type Component interface {
-	Type() string
-}
-
-// Systemer is an interface which implements a System. A System
-// iterates over the Entitys it is required by, and can process
-// their Components
-type Systemer interface {
-	// Type returns an individual string identifier, usually the struct name
+// System is an interface which implements an ECS-System. A System
+// should iterate over its Entities on `Update`, in any way suitable
+// for the current implementation.
+type System interface {
+	// Type returns a unique string identifier, usually the struct name
 	// eg. "RenderSystem", "CollisionSystem"...
 	Type() string
-	// Priority is used to create the order in which Systemers are processed
+	// Priority is used to create the order in which Systems (in the World) are processed
 	Priority() int
-	// RunInParallel checks whether the System can run in parallel. This is ran every update,
-	// so it is possible to run serial when the system has < 10 entities, and then run in parallel
-	// when not
-	RunInParallel() bool
 
 	// New is the initialisation of the System
 	New(*World)
-	// Pre is ran just before the System updates, every frame
-	Pre()
-	// Post is ran just after the System updates, every frame
-	Post()
-	// Update is ran every frame, and for each Entity which belongs to the
-	// System
-	Update(entity *Entity, dt float32)
+	// Update is ran every frame, with `dt` being the time in seconds since the last frame
+	Update(dt float32)
 
-	// Entities returns a slice of all Entities
-	Entities() []*Entity
 	// AddEntity adds a new Entity to the System
 	AddEntity(entity *Entity)
-	// AddEntity removes an Entity from the System
+	// RemoveEntity removes an Entity from the System
 	RemoveEntity(entity *Entity)
 }
 
-// System is the default implementation of the Systemer interface.
-type System struct {
-	EntityMap            map[string]*Entity
-	ShouldSkipOnHeadless bool
-}
+// Systems implements a sortable list of `System`. It is indexed on `System.Priority()`.
+type Systems []System
 
-// NewSystem returns a new default System
-func NewSystem() *System {
-	s := &System{}
-	s.EntityMap = make(map[string]*Entity)
-	return s
-}
-
-func (s System) New()  {}
-func (s System) Pre()  {}
-func (s System) Post() {}
-
-func (s System) Priority() int {
-	return 0
-}
-func (s System) RunInParallel() bool { return false }
-
-func (s System) Entities() []*Entity {
-	list := make([]*Entity, len(s.EntityMap))
-	i := 0
-	for _, ent := range s.EntityMap {
-		list[i] = ent
-		i++
-	}
-	return list
-}
-
-func (s *System) AddEntity(entity *Entity) {
-	s.EntityMap[entity.ID()] = entity
-}
-
-func (s *System) RemoveEntity(entity *Entity) {
-	delete(s.EntityMap, entity.ID())
-}
-
-// Systemers implements a sortable list of System. It is indexed on System.Priority().
-type Systemers []Systemer
-
-func (s Systemers) Len() int {
+func (s Systems) Len() int {
 	return len(s)
 }
 
-func (s Systemers) Less(i, j int) bool {
-	return s[i].Priority() < s[j].Priority()
+func (s Systems) Less(i, j int) bool {
+	return s[i].Priority() > s[j].Priority()
 }
 
-func (s Systemers) Swap(i, j int) {
+func (s Systems) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -90,11 +90,22 @@ func (w *World) RemoveEntity(entity *Entity) {
 // AddSystem adds a new System to the World, and then sorts them based on Priority
 func (w *World) AddSystem(system System) {
 	// Special checks for LinearSystem
-	if linSys, ok := (system).(basicSystemSetter); ok {
-		if basic, ok := (system).(LinearSystemFunctions); ok {
-			linSys.setLinearSystemFunctions(basic)
+	if linSys, ok := (system).(linearSystemSetter); ok {
+		var pre LinearSystemPre
+		var post LinearSystemPost
+
+		if preFunc, ok := (system).(LinearSystemPre); ok {
+			pre = preFunc
+		}
+
+		if postFunc, ok := (system).(LinearSystemPost); ok {
+			post = postFunc
+		}
+
+		if update, ok := (system).(LinearSystemUpdate); ok {
+			linSys.setLinearSystemFunctions(pre, update, post)
 		} else {
-			log.Println("Warning: Linear System", system.Type(), "does not implement ecs.BasicSystem")
+			log.Println("Warning: Linear System", system.Type(), "does not implement ecs.LinearSystemUpdate")
 		}
 	}
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -6,18 +6,13 @@ import (
 )
 
 type TestSystem struct {
-	*System
+	LinearSystem
 }
 
-func (ts *TestSystem) New(*World) {
-	ts.System = NewSystem()
-}
+func (ts *TestSystem) New(*World) {}
+func (*TestSystem) Type() string  { return "TestSystem" }
 
-func (*TestSystem) Type() string {
-	return "TestSystem"
-}
-
-func (ts *TestSystem) Update(e *Entity, dt float32) {}
+func (ts *TestSystem) UpdateEntity(e *Entity, dt float32) {}
 
 func TestAddEntity(t *testing.T) {
 	world := World{}

--- a/mouse.go
+++ b/mouse.go
@@ -59,7 +59,7 @@ func (*MouseComponent) Type() string {
 
 // MouseSystem listens for mouse events, and changes value for MouseComponent accordingly
 type MouseSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 
 	mouseX    float32
 	mouseY    float32
@@ -67,14 +67,10 @@ type MouseSystem struct {
 }
 
 // Type returns the string representation of the MouseSystem type
-func (*MouseSystem) Type() string {
-	return "MouseSystem"
-}
+func (*MouseSystem) Type() string { return "MouseSystem" }
 
 // New initializes the MouseSystem
-func (m *MouseSystem) New(*ecs.World) {
-	m.System = ecs.NewSystem()
-}
+func (m *MouseSystem) New(*ecs.World) {}
 
 // Priority returns a priority of 10 (higher than most) to ensure that this System runs before all others
 func (m *MouseSystem) Priority() int {
@@ -88,8 +84,17 @@ func (m *MouseSystem) Pre() {
 	m.mouseY = Mouse.Y*cam.z*(gameHeight/windowHeight) + cam.y - (gameHeight/2)*cam.z
 }
 
-// Update sets the MouseComponent values for each Entity
-func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
+// Post is called after all Update calls, and is used to compute internal values
+// NOTE: we do not reset modifiers here because we always set them to meaningful
+// values when a mouse event is propagated to the mouse components
+func (m *MouseSystem) Post() {
+	// reset mouse.Action value to something meaningless to avoid
+	// catching the same "signal" twice
+	Mouse.Action = NEUTRAL
+}
+
+// EUpdate sets the MouseComponent values for each Entity
+func (m *MouseSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	var (
 		mc     *MouseComponent
 		space  *SpaceComponent
@@ -181,13 +186,4 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 		}
 		mc.Hovered = false
 	}
-}
-
-// Post is called after all Update calls, and is used to compute internal values
-// NOTE: we do not reset modifiers here because we always set them to meaningful
-// values when a mouse event is propagated to the mouse components
-func (m *MouseSystem) Post() {
-	// reset mouse.Action value to something meaningless to avoid
-	// catching the same "signal" twice
-	Mouse.Action = NEUTRAL
 }

--- a/render.go
+++ b/render.go
@@ -22,6 +22,10 @@ const (
 	Hidden PriorityLevel = -1
 )
 
+const (
+	RenderSystemPriority = -1000
+)
+
 type PriorityLevel int
 
 type Drawable interface {
@@ -191,7 +195,7 @@ func (ren *RenderComponent) generateBufferContent() []float32 {
 }
 
 type RenderSystem struct {
-	*ecs.System
+	ecs.LinearSystem
 
 	renders map[PriorityLevel][]*ecs.Entity
 	changed bool
@@ -200,9 +204,7 @@ type RenderSystem struct {
 
 func (rs *RenderSystem) New(w *ecs.World) {
 	rs.renders = make(map[PriorityLevel][]*ecs.Entity)
-	rs.System = ecs.NewSystem()
 	rs.world = w
-	rs.ShouldSkipOnHeadless = true
 
 	if !headless {
 		if !Shaders.setup {
@@ -225,12 +227,12 @@ func (rs *RenderSystem) New(w *ecs.World) {
 
 func (rs *RenderSystem) AddEntity(e *ecs.Entity) {
 	rs.changed = true
-	rs.System.AddEntity(e)
+	rs.LinearSystem.AddEntity(e)
 }
 
 func (rs *RenderSystem) RemoveEntity(e *ecs.Entity) {
 	rs.changed = true
-	rs.System.RemoveEntity(e)
+	rs.LinearSystem.RemoveEntity(e)
 }
 
 func (rs *RenderSystem) Pre() {
@@ -294,7 +296,7 @@ func (rs *RenderSystem) Post() {
 	rs.changed = false
 }
 
-func (rs *RenderSystem) Update(entity *ecs.Entity, dt float32) {
+func (rs *RenderSystem) UpdateEntity(entity *ecs.Entity, dt float32) {
 	if !rs.changed {
 		return
 	}
@@ -313,6 +315,6 @@ func (*RenderSystem) Type() string {
 	return "RenderSystem"
 }
 
-func (rs *RenderSystem) Priority() int {
-	return 1
+func (*RenderSystem) Priority() int {
+	return RenderSystemPriority
 }


### PR DESCRIPTION
Fixes #119

# Breaking change
Things like
```go
type MyCustomSystem struct {
    *ecs.System
}
```
have become
```go
type MyCustomSystem struct {
    *ecs.BasicSystemWrapper
}
```
----------------
Things like
```go
func (m *MyCustomSystem) New(*ecs.World) {
    m.System = ecs.NewSystem()
}
```
have become
```go
func (m *MyCustomSystem) New(*ecs.World) {
    m.BasicSystemWrapper = ecs.NewBasicSystemWrapper(m)
}
```
------------
Things like
```go
func (*MyCustomSystem) Update(*ecs.Entity, float32) {}
```
have become
```go
func (*MyCustomSystem) EUpdate(*ecs.Entity, float32) {}
```

# New features
A valid `System` (which you can add to a `World` instance), is this:
```go
type MyCustomSystem struct {}
func (*MyCustomSystem) Type() string { return "MyCustomSystem" }
func (*MyCustomSystem) Priority() int { return 1 }
func (*MyCustomSystem) AddEntity(*ecs.Entity) {}
func (*MyCustomSystem) RemoveEntity(*ecs.Entity) {}
func (*MyCustomSystem) New(*ecs.World) {}
func (*MyCustomSystem) Update(dt float32) {}
```
One can still use the 'old' behavior which does the looping-over-entities for you, this can be done like:
```go
type MyCustomSys struct {
    *ecs.BasicSystemWrapper
}
func (*MyCustomSys) Type() string { return "MyCustomSys" }
func (*MyCustomSys) Pre() {}
func (*MyCustomSys) Post() {}
func (m *MyCustomSys) New(*ecs.World) {
    m.BasicSystemWrapper = ecs.NewBasicSystemWrapper(m)
}
func (*MyCustomSys) EUpdate(*ecs.Entity, float32) {}
```