### PR TITLE
Removed experimental HUDShader design

### DIFF
--- a/font.go
+++ b/font.go
@@ -119,7 +119,7 @@ func (f *Font) Render(text string) *Texture {
 	c.SetSrc(fg)
 
 	// Draw the text.
-	pt := freetype.Pt(0, int(yBearing))
+	pt := fixed.P(0, int(yBearing))
 	_, err := c.DrawString(text, pt)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
`HUDShader` now works mostly like `DefaultShader`,
instead of the (experimental) optimalizations.

More specifically: instead of having an `ELEMENT_ARRAY_BUFFER`
with the coordinates (of where to draw), and calling a single `DrawElements`; it now
works by calling `DrawElements` every time and setting the location as uniform (across the vertices),
instead of in the buffer.

Fixes #144.

Review if you want, LGTM. 