### PR TITLE
Detect unmet dependencies in entities at adding time to world

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,15 +1,16 @@
 package engi
 
 import (
-	"github.com/paked/engi/ecs"
 	"testing"
+
+	"github.com/paked/engi/ecs"
 )
 
 type NilSystem struct {
 	*ecs.System
 }
 
-func (ns *NilSystem) New() {
+func (ns *NilSystem) New(*ecs.World) {
 	ns.System = ecs.NewSystem()
 }
 

--- a/camera.go
+++ b/camera.go
@@ -87,7 +87,7 @@ func (cam *cameraSystem) moveToX(location float32) {
 }
 
 func (cam *cameraSystem) moveToY(location float32) {
-	cam.y = mgl32.Clamp(location, WorldBounds.Min.X, WorldBounds.Max.Y)
+	cam.y = mgl32.Clamp(location, WorldBounds.Min.Y, WorldBounds.Max.Y)
 }
 
 func (cam *cameraSystem) zoomTo(zoomLevel float32) {

--- a/camera_test.go
+++ b/camera_test.go
@@ -3,11 +3,15 @@ package engi
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/paked/engi/ecs"
 )
 
 func TestCameraMoveX(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
 
 	currentX := cam.X()
@@ -38,8 +42,10 @@ func TestCameraMoveX(t *testing.T) {
 }
 
 func TestCameraMoveY(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
 
 	currentY := cam.Y()
@@ -70,8 +76,10 @@ func TestCameraMoveY(t *testing.T) {
 }
 
 func TestCameraZoom(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 
 	currentZ := cam.Z()
 
@@ -101,8 +109,10 @@ func TestCameraZoom(t *testing.T) {
 }
 
 func TestCameraMoveToX(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
 
 	currentX := cam.X()
@@ -118,8 +128,10 @@ func TestCameraMoveToX(t *testing.T) {
 }
 
 func TestCameraMoveToY(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 	WorldBounds = AABB{Point{0, 0}, Point{300, 300}}
 
 	currentY := cam.Y()
@@ -135,8 +147,10 @@ func TestCameraMoveToY(t *testing.T) {
 }
 
 func TestCameraZoomTo(t *testing.T) {
+	w := &ecs.World{}
+	w.New()
 	cam := &cameraSystem{}
-	cam.New()
+	cam.New(w)
 
 	currentZ := cam.Z()
 

--- a/demos/animation/anim.go
+++ b/demos/animation/anim.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
 )
@@ -37,7 +39,10 @@ func (game *GameWorld) Setup(w *ecs.World) {
 
 	spriteSheet := engi.NewSpritesheetFromFile("hero.png", 150, 150)
 
-	w.AddEntity(game.CreateEntity(&engi.Point{0, 0}, spriteSheet, StopAction))
+	err := w.AddEntity(game.CreateEntity(&engi.Point{0, 0}, spriteSheet, StopAction))
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*GameWorld) Hide()        {}

--- a/demos/audio/audio.go
+++ b/demos/audio/audio.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
 )
@@ -20,7 +22,10 @@ func (game *Game) Setup(w *ecs.World) {
 	backgroundMusic := ecs.NewEntity([]string{"AudioSystem"})
 	backgroundMusic.AddComponent(&engi.AudioComponent{File: "326488.wav", Repeat: true, Background: true})
 
-	w.AddEntity(backgroundMusic)
+	err := w.AddEntity(backgroundMusic)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*Game) Hide()        {}

--- a/demos/edgescroller/escroller.go
+++ b/demos/edgescroller/escroller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"image"
 	"image/color"
+	"log"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
@@ -61,7 +62,10 @@ func (game *Game) Setup(w *ecs.World) {
 	w.AddSystem(engi.NewEdgeScroller(scrollSpeed, edgeMargin))
 
 	// Create the background; this way we'll see when we actually scroll
-	w.AddEntity(generateBackground())
+	err := w.AddEntity(generateBackground())
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*Game) Hide()        {}

--- a/demos/entity/entity.go
+++ b/demos/entity/entity.go
@@ -37,7 +37,10 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	guy.AddComponent(render)
 	guy.AddComponent(space)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*GameWorld) Hide()        {}

--- a/demos/falling/falling.go
+++ b/demos/falling/falling.go
@@ -42,7 +42,10 @@ func (game *Game) Setup(w *ecs.World) {
 	guy.AddComponent(space)
 	guy.AddComponent(collision)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*Game) Hide()        {}
@@ -109,7 +112,10 @@ func (rock *RockSpawnSystem) Update(entity *ecs.Entity, dt float32) {
 
 	position := engi.Point{0, -32}
 	position.X = rand.Float32() * (engi.Width())
-	rock.world.AddEntity(NewRock(position))
+	err := rock.world.AddEntity(NewRock(position))
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func NewRock(position engi.Point) *ecs.Entity {

--- a/demos/headless/headless.go
+++ b/demos/headless/headless.go
@@ -46,7 +46,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 	ball.AddComponent(ballSpace)
 	ball.AddComponent(ballCollision)
 	ball.AddComponent(ballSpeed)
-	w.AddEntity(ball)
+	err := w.AddEntity(ball)
+	if err != nil {
+		log.Println(err)
+	}
 
 	score := ecs.NewEntity([]string{"RenderSystem", "ScoreSystem"})
 
@@ -54,7 +57,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 	scoreSpace := &engi.SpaceComponent{engi.Point{100, 100}, 100, 100}
 	score.AddComponent(scoreRender)
 	score.AddComponent(scoreSpace)
-	w.AddEntity(score)
+	err = w.AddEntity(score)
+	if err != nil {
+		log.Println(err)
+	}
 
 	schemes := []string{"WASD", ""}
 	for i := 0; i < 2; i++ {
@@ -72,7 +78,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 		paddle.AddComponent(paddleSpace)
 		paddle.AddComponent(paddleControl)
 		paddle.AddComponent(paddleCollision)
-		w.AddEntity(paddle)
+		err = w.AddEntity(paddle)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }
 

--- a/demos/hello/hello.go
+++ b/demos/hello/hello.go
@@ -39,7 +39,10 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	guy.AddComponent(space)
 	guy.AddComponent(collision)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*GameWorld) Hide()        {}

--- a/demos/hide/hide.go
+++ b/demos/hide/hide.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"math/rand"
 
 	"github.com/paked/engi"
@@ -33,7 +34,10 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	guy.AddComponent(space)
 	guy.AddComponent(collision)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*GameWorld) Hide()        {}

--- a/demos/hud/hud.go
+++ b/demos/hud/hud.go
@@ -3,6 +3,7 @@ package main
 import (
 	"image"
 	"image/color"
+	"log"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
@@ -84,7 +85,10 @@ func (game *Game) Setup(w *ecs.World) {
 	w.AddSystem(engi.NewMouseZoomer(zoomSpeed))
 
 	// Create background, so we can see difference between this and HUD
-	w.AddEntity(generateBackground())
+	err := w.AddEntity(generateBackground())
+	if err != nil {
+		log.Println(err)
+	}
 
 	// Creating the HUD
 	hudWidth := float32(200)         // Can be anything you want
@@ -92,7 +96,10 @@ func (game *Game) Setup(w *ecs.World) {
 
 	// Generate something that uses the PriorityLevel HUDGround or up
 	hudBg := generateHUDBackground(hudWidth, hudHeight)
-	w.AddEntity(hudBg)
+	err = w.AddEntity(hudBg)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*Game) Hide()        {}

--- a/demos/keyboardscroller/kbscroller.go
+++ b/demos/keyboardscroller/kbscroller.go
@@ -3,6 +3,7 @@ package main
 import (
 	"image"
 	"image/color"
+	"log"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
@@ -64,7 +65,10 @@ func (game *Game) Setup(w *ecs.World) {
 	w.AddSystem(engi.NewKeyboardScroller(scrollSpeed, engi.W, engi.D, engi.S, engi.A))
 
 	// Create the background; this way we'll see when we actually scroll
-	w.AddEntity(generateBackground())
+	err := w.AddEntity(generateBackground())
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func main() {

--- a/demos/mouse/mouse.go
+++ b/demos/mouse/mouse.go
@@ -3,6 +3,7 @@ package main
 import (
 	"image"
 	"image/color"
+	"log"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
@@ -41,7 +42,10 @@ func (game *GameWorld) Setup(w *ecs.World) {
 	w.AddSystem(&ControlSystem{})
 	w.AddSystem(engi.NewMouseZoomer(-0.125))
 
-	w.AddEntity(game.CreateEntity())
+	err := w.AddEntity(game.CreateEntity())
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*GameWorld) Hide()        {}

--- a/demos/pong/pong.go
+++ b/demos/pong/pong.go
@@ -47,7 +47,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 	ball.AddComponent(ballSpace)
 	ball.AddComponent(ballCollision)
 	ball.AddComponent(ballSpeed)
-	w.AddEntity(ball)
+	err := w.AddEntity(ball)
+	if err != nil {
+		log.Println(err)
+	}
 
 	score := ecs.NewEntity([]string{"RenderSystem", "ScoreSystem"})
 
@@ -56,7 +59,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 	scoreSpace := &engi.SpaceComponent{engi.Point{100, 100}, 100, 100}
 	score.AddComponent(scoreRender)
 	score.AddComponent(scoreSpace)
-	w.AddEntity(score)
+	err = w.AddEntity(score)
+	if err != nil {
+		log.Println(err)
+	}
 
 	schemes := []string{"WASD", ""}
 	for i := 0; i < 2; i++ {
@@ -75,7 +81,10 @@ func (pong *PongGame) Setup(w *ecs.World) {
 		paddle.AddComponent(paddleSpace)
 		paddle.AddComponent(paddleControl)
 		paddle.AddComponent(paddleCollision)
-		w.AddEntity(paddle)
+		err = w.AddEntity(paddle)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }
 

--- a/demos/scenes/scenes.go
+++ b/demos/scenes/scenes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"time"
 
@@ -42,7 +43,10 @@ func (game *IconScene) Setup(w *ecs.World) {
 	guy.AddComponent(space)
 	guy.AddComponent(collision)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*IconScene) Hide()        {}
@@ -77,7 +81,10 @@ func (game *RockScene) Setup(w *ecs.World) {
 	guy.AddComponent(space)
 	guy.AddComponent(collision)
 
-	w.AddEntity(guy)
+	err := w.AddEntity(guy)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*RockScene) Hide()        {}

--- a/demos/tilemap.go
+++ b/demos/tilemap.go
@@ -39,7 +39,10 @@ func (game *GameWorld) Setup() {
 	gameMap.AddComponent(mapRender)
 	gameMap.AddComponent(mapSpace)
 
-	game.AddEntity(gameMap)
+	err := game.AddEntity(gameMap)
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func main() {

--- a/demos/zoom/zoom.go
+++ b/demos/zoom/zoom.go
@@ -3,6 +3,7 @@ package main
 import (
 	"image"
 	"image/color"
+	"log"
 
 	"github.com/paked/engi"
 	"github.com/paked/engi/ecs"
@@ -58,7 +59,10 @@ func (game *Game) Setup(w *ecs.World) {
 	w.AddSystem(engi.NewMouseZoomer(zoomSpeed))
 
 	// Create the background; this way we'll see when we actually zoom
-	w.AddEntity(generateBackground())
+	err := w.AddEntity(generateBackground())
+	if err != nil {
+		log.Println(err)
+	}
 }
 
 func (*Game) Hide()        {}

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -32,6 +32,18 @@ func (e *Entity) DoesRequire(name string) bool {
 	return e.requires[name]
 }
 
+// Requirements returns a list of all system requirements for this entity
+func (e *Entity) Requirements() []string {
+	keys := make([]string, len(e.requires))
+
+	i := 0
+	for k := range e.requires {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 // AddComponent adds a new Component to the Entity
 func (e *Entity) AddComponent(component Component) {
 	e.components[component.Type()] = component

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 )
 
-// World contains a bunch of Entitys, and a bunch of Systems. It is
-// the recommended way to run ecs
+// World contains a bunch of Entities, and a bunch of Systems.
+// It is the recommended way to run ecs
 type World struct {
 	entities map[string]*Entity
 	systems  Systemers

--- a/mouse.go
+++ b/mouse.go
@@ -47,6 +47,9 @@ type MouseComponent struct {
 	// that must really be aware of the mouse details event when the
 	// mouse is not hovering them
 	Track bool
+	// Modifier is used to store the eventual modifiers that were pressed during
+	// the same time the different click events occurred
+	Modifier Modifier
 }
 
 // Type returns the string representation of the MouseComponent type
@@ -138,6 +141,10 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 		mc.MouseX = mx
 		mc.MouseY = my
 
+		// propagate the modifiers to the mouse component so that game
+		// implementers can take different decisions based on those
+		mc.Modifier = Mouse.Modifer
+
 		switch Mouse.Action {
 		case PRESS:
 			switch Mouse.Button {
@@ -168,12 +175,17 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 	} else {
 		if mc.Hovered {
 			mc.Leave = true
+			// propagate the modifiers to the mouse component so that game
+			// implementers can take different decisions based on those
+			mc.Modifier = Mouse.Modifer
 		}
 		mc.Hovered = false
 	}
 }
 
 // Post is called after all Update calls, and is used to compute internal values
+// NOTE: we do not reset modifiers here because we always set them to meaningful
+// values when a mouse event is propagated to the mouse components
 func (m *MouseSystem) Post() {
 	// reset mouse.Action value to something meaningless to avoid
 	// catching the same "signal" twice

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,37 @@
+package engi
+
+import (
+	"testing"
+
+	"github.com/paked/engi/ecs"
+)
+
+type inlineGame struct {
+	preloadFunc func()
+	setupFunc   func(*ecs.World)
+}
+
+func (m *inlineGame) Preload() {
+	m.preloadFunc()
+}
+
+func (m *inlineGame) Setup(w *ecs.World) {
+	m.setupFunc(w)
+}
+
+// Bench is a helper-function to easily benchmark one frame, given a preload / setup function
+func Bench(b *testing.B, preload func(), setup func(w *ecs.World)) {
+	g := &inlineGame{preloadFunc: preload, setupFunc: setup}
+
+	w := &ecs.World{}
+	w.New()
+
+	g.Preload()
+	g.Setup(w)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		w.Update(1 / 120) // 120 fps
+	}
+}


### PR DESCRIPTION
Hi,

Here is the beginning of a PR / Proposition to add some control / error checking on the entity requirements. ATM the PR only adds logging to warn the developer an entity is being added to a world that does not have the sufficient systems to support its operation.

We could add an error return to the  (*ecs.World).AddEntity signature and this would break all previous code relying on the old signature. Should we make this breaking change while we can or should we just keep the logging version?

Introducing this new feature I added a new private field (systemMap) to ecs.World for my own use and I also took advantage of it in (*ecs.World).HasSystem() implementation.