### PR TITLE
RenderComponent now has readable values

### DIFF
--- a/render.go
+++ b/render.go
@@ -72,9 +72,17 @@ func (r *RenderComponent) SetPriority(p PriorityLevel) {
 	Mailbox.Dispatch(renderChangeMessage{})
 }
 
+func (r *RenderComponent) Priority() PriorityLevel {
+	return r.priority
+}
+
 func (r *RenderComponent) SetDrawable(d Drawable) {
 	r.drawable = d
 	r.preloadTexture()
+}
+
+func (r *RenderComponent) Drawable() Drawable {
+	return r.drawable
 }
 
 func (r *RenderComponent) SetScale(scale Point) {


### PR DESCRIPTION
Values like `Drawable`, `Scale` and `PriorityLevel` require changes
to be done through a separate `SetXXXXXX` function (for caching purposes).

With this commit, the values that were once set by such a function,
can now be read.

Small PR, so feel free to merge. 