### PR TITLE
Fixed issue where MouseComponent would stay Clicked

### DIFF
--- a/mouse.go
+++ b/mouse.go
@@ -87,6 +87,9 @@ func (m *MouseSystem) Pre() {
 
 // Update sets the MouseComponent values for each Entity
 func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
+	mx := m.mouseX
+	my := m.mouseY
+
 	var (
 		mc     *MouseComponent
 		space  *SpaceComponent
@@ -99,6 +102,21 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 		return
 	}
 
+	// Reset all values except these
+	*mc = MouseComponent{
+		Track:   mc.Track,
+		Hovered: mc.Hovered,
+	}
+
+	if mc.Track {
+		// track mouse position so that systems that need to stay on the mouse
+		// position can do it (think an RTS when placing a new building and
+		// you get a ghost building following your mouse until you click to
+		// place it somewhere in your world.
+		mc.MouseX = mx
+		mc.MouseY = my
+	}
+
 	// We need SpaceComponent for the location
 	if space, ok = entity.ComponentFast(space).(*SpaceComponent); !ok {
 		return
@@ -108,12 +126,6 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 	if render, ok = entity.ComponentFast(render).(*RenderComponent); !ok {
 		return
 	}
-
-	// Reset some values
-	mc.Leave = false
-
-	mx := m.mouseX
-	my := m.mouseY
 
 	// Special case: HUD
 	if render.priority >= HUDGround {
@@ -129,14 +141,13 @@ func (m *MouseSystem) Update(entity *ecs.Entity, dt float32) {
 
 		mc.Enter = !mc.Hovered
 		mc.Hovered = true
-
 		mc.Released = false
-		// track mouse position so that systems that need to stay on the mouse
-		// position can do it (think an RTS when placing a new building and
-		// you get a ghost building following your mouse until you click to
-		// place it somewhere in your world.
-		mc.MouseX = mx
-		mc.MouseY = my
+
+		if !mc.Track {
+			// If we're tracking, we've already set these
+			mc.MouseX = mx
+			mc.MouseY = my
+		}
 
 		switch Mouse.Action {
 		case PRESS:


### PR DESCRIPTION
Instead of resetting most values to false, we're now
forgetting every value from the last frame (with some
exceptions), to ensure things like `Click` don't fire twice. (which they do now)

Would you like to review @faide ?