### PR TITLE
Fixed compiler issues on Windows

### DIFF
--- a/audio.go
+++ b/audio.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package engi
 
 import (

--- a/audio_player.go
+++ b/audio_player.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package engi
 
 // Taken from golang.org/x/mobile/exp/audio

--- a/audio_windows.go
+++ b/audio_windows.go
@@ -4,18 +4,24 @@ import (
 	"log"
 
 	"github.com/paked/engi/ecs"
+	"io"
 )
 
 const (
 	defaultHeightModifier float32 = 1
 )
 
+// ReadSeekCloser is an io.ReadSeeker and io.Closer.
+type ReadSeekCloser interface {
+	io.ReadSeeker
+	io.Closer
+}
+
 // AudioComponent is a Component which is used by the AudioSystem
 type AudioComponent struct {
 	File       string
 	Repeat     bool
 	Background bool
-	player     *Player
 }
 
 func (*AudioComponent) Type() string {


### PR DESCRIPTION
Still does not fix the usage of audio on Windows, just
handles the compilation.

Fixes #140. 